### PR TITLE
관리자 강의 목록 페이지 구현완료

### DIFF
--- a/views/lectureList/LectureAdd.vue
+++ b/views/lectureList/LectureAdd.vue
@@ -1,28 +1,57 @@
 <template>
   <div class="addLecture">
-    <div class="ui horizontal divider">
-      강의 추가
-    </div>
-    <div class="ui form success">
-      <div class="field">
-        <label>강의명</label>
-        <input type="text" placeholder="강의명을 입력해주세요.">
+    <form>
+      <div class="ui horizontal divider">
+        강의 추가
       </div>
-      <div class="ui success message">
-        <div class="header">강의를 생성할 수 있습니다.</div>
-        <p>강의 추가 버튼을 클릭해 강의를 생성하세요.</p>
+      <div class="ui form success">
+        <div class="field">
+          <label>강의명</label>
+          <input type="text" v-model="newLectureName" placeholder="강의명을 입력해주세요.">
+        </div>
+        <div class="ui success message">
+          <div class="header">강의를 생성할 수 있습니다.</div>
+          <p>강의 추가 버튼을 클릭해 강의를 생성하세요.</p>
+        </div>
+        <div class="ui error message">
+          <div class="header">Action Forbidden</div>
+          <p>You can only sign up for an account once with a given e-mail address.</p>
+        </div>
+        <div
+          class="ui submit button"
+          v-on:click="addNewLecture"
+        >강의 추가</div>
       </div>
-      <div class="ui error message">
-        <div class="header">Action Forbidden</div>
-        <p>You can only sign up for an account once with a given e-mail address.</p>
-      </div>
-      <div class="ui submit button">강의 추가</div>
-    </div>
+    </form>
+    <pre>
+      {{ $data }}
+    </pre>
   </div>
 </template>
 
 <script>
+  //import axios from 'axios'
 
+  export default {
+    props: ['lectures'],
+    data() {
+      return {
+        newLectureName:'',
+        professorName: '이승진',
+        lectures: this.lectures
+      }
+    },
+    methods: {
+      addNewLecture: function () {
+        this.lectures.push({
+          title: this.newLectureName,
+          professor: this.professorName,
+          open: false
+        })
+        this.newLectureName = ''
+      }
+    }
+  }
 </script>
 
 <style scoped>
@@ -34,5 +63,8 @@
   }
   .ui.success.message {
     background-color: #fcfff5 !important;
+  }
+  .ui.button {
+    float: right;
   }
 </style>

--- a/views/lectureList/LectureAdd.vue
+++ b/views/lectureList/LectureAdd.vue
@@ -24,24 +24,20 @@
         <div
           v-if="isError"
           class="ui error message">
-          <div class="header">Action Forbidden</div>
-          <p>You can only sign up for an account once with a given e-mail address.</p>
+          <div class="header">강의를 생성할 수 없습니다.</div>
+          <p>중복되는 강의명을 입력했습니다. 변경해주세요.</p>
         </div>
         <div
           class="ui submit button"
+          :class=" { disabled: isError } "
           v-on:click="addNewLecture"
         >강의 추가</div>
       </div>
     </form>
-    <pre>
-      {{ $data }}
-    </pre>
   </div>
 </template>
 
 <script>
-  //import axios from 'axios'
-
   export default {
     props: ['lectures'],
     data() {
@@ -55,37 +51,34 @@
     },
     methods: {
       addNewLecture: function () {
-        this.lectures.push({
-          title: this.newLectureName,
-          professor: this.professorName,
-          open: false
-        })
-        this.newLectureName = ''
+        if(this.newLectureName.length > 0) {
+          this.lectures.push({
+            title: this.newLectureName,
+            professor: this.professorName,
+            open: false
+          })
+          this.newLectureName = ''
+        } else {
+          alert('강의명을 입력해주세요.');
+        }
       }
     },
     computed: {
       isError() {
-        if(this.newLectureName.length > 0) {
-          let newLecture = this.newLectureName;
-          this.lectures.forEach(function (item) {
-            if(item.title === newLecture){
-              console.log(item.title + 'vs' + newLecture)
+        let newLectureTitle = this.newLectureName;
+          for(let i = 0; i < this.lectures.length; i++) {
+            if(newLectureTitle == this.lectures[i].title)
               return true;
-            }
-          })
-        }
-        return false;
+          }
       },
       isSuccess() {
-        if(this.newLectureName.length > 0) {
-          let newLecture = this.newLectureName;
-          this.lectures.forEach(function (item) {
-            if (item.title === newLecture) {
-              console.log(item.title === newLecture)
+        let newLectureTitle = this.newLectureName;
+        if(newLectureTitle.length > 0) {
+          for(let i = 0; i < this.lectures.length; i++) {
+            if(newLectureTitle == this.lectures[i].title)
               return false;
-            }
-            return true;
-          })
+          }
+          return true;
         }
       }
     }
@@ -94,7 +87,7 @@
 
 <style scoped>
   .addLecture {
-    margin: 0 15% 3% 15%;
+    margin: 0 15% 5% 15%;
   }
   .success {
     background-color: white !important;
@@ -104,5 +97,11 @@
   }
   .ui.button {
     float: right;
+  }
+  .error {
+    background-color: white !important;
+  }
+  .ui.error.message {
+    background-color: #fff6f6 !important;
   }
 </style>

--- a/views/lectureList/LectureAdd.vue
+++ b/views/lectureList/LectureAdd.vue
@@ -1,0 +1,38 @@
+<template>
+  <div class="addLecture">
+    <div class="ui horizontal divider">
+      강의 추가
+    </div>
+    <div class="ui form success">
+      <div class="field">
+        <label>강의명</label>
+        <input type="text" placeholder="강의명을 입력해주세요.">
+      </div>
+      <div class="ui success message">
+        <div class="header">강의를 생성할 수 있습니다.</div>
+        <p>강의 추가 버튼을 클릭해 강의를 생성하세요.</p>
+      </div>
+      <div class="ui error message">
+        <div class="header">Action Forbidden</div>
+        <p>You can only sign up for an account once with a given e-mail address.</p>
+      </div>
+      <div class="ui submit button">강의 추가</div>
+    </div>
+  </div>
+</template>
+
+<script>
+
+</script>
+
+<style scoped>
+  .addLecture {
+    margin: 0 15% 3% 15%;
+  }
+  .success {
+    background-color: white !important;
+  }
+  .ui.success.message {
+    background-color: #fcfff5 !important;
+  }
+</style>

--- a/views/lectureList/LectureAdd.vue
+++ b/views/lectureList/LectureAdd.vue
@@ -4,16 +4,26 @@
       <div class="ui horizontal divider">
         강의 추가
       </div>
-      <div class="ui form success">
+      <div
+        class="ui form"
+        :class="{ success: isSuccess, error: isError}"
+      >
         <div class="field">
           <label>강의명</label>
-          <input type="text" v-model="newLectureName" placeholder="강의명을 입력해주세요.">
+          <input
+            type="text"
+            v-model="newLectureName"
+            placeholder="강의명을 입력해주세요.">
         </div>
-        <div class="ui success message">
+        <div
+          v-if="isSuccess"
+          class="ui success message">
           <div class="header">강의를 생성할 수 있습니다.</div>
           <p>강의 추가 버튼을 클릭해 강의를 생성하세요.</p>
         </div>
-        <div class="ui error message">
+        <div
+          v-if="isError"
+          class="ui error message">
           <div class="header">Action Forbidden</div>
           <p>You can only sign up for an account once with a given e-mail address.</p>
         </div>
@@ -38,7 +48,9 @@
       return {
         newLectureName:'',
         professorName: '이승진',
-        lectures: this.lectures
+        lectures: this.lectures,
+        //isSuccess: false,
+        error: false
       }
     },
     methods: {
@@ -49,6 +61,32 @@
           open: false
         })
         this.newLectureName = ''
+      }
+    },
+    computed: {
+      isError() {
+        if(this.newLectureName.length > 0) {
+          let newLecture = this.newLectureName;
+          this.lectures.forEach(function (item) {
+            if(item.title === newLecture){
+              console.log(item.title + 'vs' + newLecture)
+              return true;
+            }
+          })
+        }
+        return false;
+      },
+      isSuccess() {
+        if(this.newLectureName.length > 0) {
+          let newLecture = this.newLectureName;
+          this.lectures.forEach(function (item) {
+            if (item.title === newLecture) {
+              console.log(item.title === newLecture)
+              return false;
+            }
+            return true;
+          })
+        }
       }
     }
   }

--- a/views/lectureList/LectureAdder.vue
+++ b/views/lectureList/LectureAdder.vue
@@ -58,6 +58,7 @@
     methods: {
       addLecture: function () {
         this.$emit('addLecture', this.newLectureName)
+        this.newLectureName = ''
       }
     },
     computed: {

--- a/views/lectureList/LectureAdder.vue
+++ b/views/lectureList/LectureAdder.vue
@@ -30,7 +30,7 @@
         <div
           class="ui submit button"
           :class=" { disabled: isError } "
-          v-on:click="addNewLecture"
+          v-on:click="addLecture"
         >강의 추가</div>
       </div>
     </form>
@@ -39,7 +39,13 @@
 
 <script>
   export default {
-    props: ['lectures'],
+    props: {
+      lectures: {
+        type: Array,
+        required: true,
+        description: "lecture list"
+      }
+    },
     data() {
       return {
         newLectureName:'',
@@ -50,17 +56,8 @@
       }
     },
     methods: {
-      addNewLecture: function () {
-        if(this.newLectureName.length > 0) {
-          this.lectures.push({
-            title: this.newLectureName,
-            professor: this.professorName,
-            open: false
-          })
-          this.newLectureName = ''
-        } else {
-          alert('강의명을 입력해주세요.');
-        }
+      addLecture: function () {
+        this.$emit('child-event', this.newLectureName)
       }
     },
     computed: {

--- a/views/lectureList/LectureAdder.vue
+++ b/views/lectureList/LectureAdder.vue
@@ -57,7 +57,7 @@
     },
     methods: {
       addLecture: function () {
-        this.$emit('child-event', this.newLectureName)
+        this.$emit('addLecture', this.newLectureName)
       }
     },
     computed: {

--- a/views/lectureList/LectureList.vue
+++ b/views/lectureList/LectureList.vue
@@ -24,11 +24,6 @@
         required: true,
         description: "lecture list"
       }
-    },
-    data() {
-      return {
-        lectures: this.lectures
-      }
     }
   }
 </script>

--- a/views/lectureList/LectureList.vue
+++ b/views/lectureList/LectureList.vue
@@ -1,0 +1,59 @@
+<template>
+  <div class="ui middle aligned divided list">
+    <div class="item" v-for="lecture in lectures">
+      <shadow-box>
+        <lecture-item v-bind:lecture="lecture"></lecture-item>
+      </shadow-box>
+    </div>
+  </div>
+</template>
+
+<script>
+  import LectureItem from "@/components/lecture/LectureItem"
+  import ShadowBox from "@/components/lecture/ShadowBox"
+  import axios from 'axios'
+
+  export default {
+    components: {
+      LectureItem,
+      ShadowBox
+    },
+    data() {
+      return {
+        lectures: []
+      }
+    },
+    created() {
+      axios.get('http://localhost:8080/server/lectures_professor.json')
+        .then((response)=>{
+          this.lectures = response.data;
+          console.log(this.lectures);
+        })
+    }
+  }
+</script>
+<style>
+  .ui.list > .item {
+    padding: 0;
+  }
+  .item:hover .content {
+    color: #0078FF;
+  }
+
+  .margin-left-150 {
+    margin-left: 150px
+  }
+
+  .margin-right-150 {
+    margin-right: 150px
+  }
+
+  .right {
+    float: right;
+  }
+
+  .ui.list {
+    margin: 1em 15%;
+    border-top: 0.0625rem solid rgba(50,50,124,0.12);
+  }
+</style>

--- a/views/lectureList/LectureList.vue
+++ b/views/lectureList/LectureList.vue
@@ -3,6 +3,11 @@
     <div class="item" v-for="lecture in lectures">
       <shadow-box>
         <lecture-item v-bind:lecture="lecture"></lecture-item>
+        <toggle
+          v-if="isProfessor"
+          v-bind:lecture="lecture"
+        >
+        </toggle>
       </shadow-box>
     </div>
   </div>
@@ -11,23 +16,27 @@
 <script>
   import LectureItem from "@/components/lecture/LectureItem"
   import ShadowBox from "@/components/lecture/ShadowBox"
+  import Toggle from "@/components/lecture/LectureToggle"
   import axios from 'axios'
 
   export default {
     components: {
       LectureItem,
-      ShadowBox
+      ShadowBox,
+      Toggle
     },
+    props: ['lectures'],
     data() {
       return {
-        lectures: []
+        lectures: this.lectures,
+        isProfessor: false
       }
     },
     created() {
-      axios.get('http://localhost:8080/server/lectures_professor.json')
-        .then((response)=>{
-          this.lectures = response.data;
-          console.log(this.lectures);
+      axios.get('http://localhost:8080/server/professorInfo.json')
+        .then((response) => {
+          this.isProfessor = response.data.isProfessor;
+          console.log(this.isProfessor);
         })
     }
   }

--- a/views/lectureList/LectureList.vue
+++ b/views/lectureList/LectureList.vue
@@ -3,11 +3,7 @@
     <div class="item" v-for="lecture in lectures">
       <shadow-box>
         <lecture-item v-bind:lecture="lecture"></lecture-item>
-        <toggle
-          v-if="isProfessor"
-          v-bind:lecture="lecture"
-        >
-        </toggle>
+        <v-switch v-model="lecture.open"></v-switch>
       </shadow-box>
     </div>
   </div>
@@ -16,28 +12,23 @@
 <script>
   import LectureItem from "@/components/lecture/LectureItem"
   import ShadowBox from "@/components/lecture/ShadowBox"
-  import Toggle from "@/components/lecture/LectureToggle"
-  import axios from 'axios'
 
   export default {
     components: {
       LectureItem,
-      ShadowBox,
-      Toggle
+      ShadowBox
     },
-    props: ['lectures'],
-    data() {
-      return {
-        lectures: this.lectures,
-        isProfessor: false
+    props: {
+      lectures: {
+        type: Array,
+        required: true,
+        description: "lecture list"
       }
     },
-    created() {
-      axios.get('http://localhost:8080/server/professorInfo.json')
-        .then((response) => {
-          this.isProfessor = response.data.isProfessor;
-          console.log(this.isProfessor);
-        })
+    data() {
+      return {
+        lectures: this.lectures
+      }
     }
   }
 </script>
@@ -64,5 +55,10 @@
   .ui.list {
     margin: 1em 15%;
     border-top: 0.0625rem solid rgba(50,50,124,0.12);
+  }
+
+  .v-input--selection-controls {
+    float: right;
+    margin-top: -60px;
   }
 </style>

--- a/views/lectureList/LectureListPage.vue
+++ b/views/lectureList/LectureListPage.vue
@@ -14,13 +14,15 @@
   import HeaderMenu from '@/components/header/HeaderMenu'
   import LectureList from '@/admin/views/lectureList/LectureList'
   import LectureAdder from '@/admin/views/lectureList/LectureAdder'
+  import Lecture from '@/models/lecture/Lecture';
   import axios from 'axios'
 
   export default {
     components: {
       HeaderMenu,
       LectureList,
-      LectureAdder
+      LectureAdder,
+      Lecture
     },
     data() {
       return {
@@ -30,11 +32,9 @@
     methods: {
       addNewLecture: function (lectureName) {
         if (lectureName.length > 0) {
-          this.lectures.push({
-            title: lectureName,
-            professor: '이승진',
-            open: false
-          })
+          this.lectures.push(
+            new Lecture(lectureName, '이승진')
+          )
         } else {
           alert('강의명을 입력해주세요.');
         }

--- a/views/lectureList/LectureListPage.vue
+++ b/views/lectureList/LectureListPage.vue
@@ -3,25 +3,41 @@
     <header-menu></header-menu>
     <h1 class="title">강의 목록</h1>
     <lecture-list :lectures="lectures"></lecture-list>
-    <lecture-add :lectures="lectures"></lecture-add>
+    <lecture-adder
+      :lectures="lectures"
+      @child-event="parentsMethod"
+    ></lecture-adder>
   </div>
 </template>
 
 <script>
   import HeaderMenu from '@/components/header/HeaderMenu'
   import LectureList from '@/admin/views/lectureList/LectureList'
-  import LectureAdd from '@/admin/views/lectureList/LectureAdd'
+  import LectureAdder from '@/admin/views/lectureList/LectureAdder'
   import axios from 'axios'
 
   export default {
     components: {
       HeaderMenu,
       LectureList,
-      LectureAdd
+      LectureAdder
     },
     data() {
       return {
         lectures: []
+      }
+    },
+    methods: {
+      parentsMethod: function (lectureName) {
+        if (lectureName.length > 0) {
+          this.lectures.push({
+            title: lectureName,
+            professor: '이승진',
+            open: false
+          })
+        } else {
+          alert('강의명을 입력해주세요.');
+        }
       }
     },
     created() {

--- a/views/lectureList/LectureListPage.vue
+++ b/views/lectureList/LectureListPage.vue
@@ -5,7 +5,7 @@
     <lecture-list :lectures="lectures"></lecture-list>
     <lecture-adder
       :lectures="lectures"
-      @child-event="parentsMethod"
+      @addLecture="addNewLecture"
     ></lecture-adder>
   </div>
 </template>
@@ -28,7 +28,7 @@
       }
     },
     methods: {
-      parentsMethod: function (lectureName) {
+      addNewLecture: function (lectureName) {
         if (lectureName.length > 0) {
           this.lectures.push({
             title: lectureName,

--- a/views/lectureList/LectureListPage.vue
+++ b/views/lectureList/LectureListPage.vue
@@ -3,17 +3,20 @@
     <header-menu></header-menu>
     <h1 class="title">강의 목록</h1>
     <lecture-list></lecture-list>
+    <lecture-add></lecture-add>
   </div>
 </template>
 
 <script>
   import HeaderMenu from '@/components/header/HeaderMenu'
   import LectureList from '@/admin/views/lectureList/LectureList'
+  import LectureAdd from '@/admin/views/lectureList/LectureAdd'
 
   export default {
     components: {
       HeaderMenu,
-      LectureList
+      LectureList,
+      LectureAdd
     }
   }
 </script>
@@ -25,13 +28,6 @@
   .title {
     padding: 2% 15% 2% 16%;
     font-size: 25px;
-    font-weight: 800;
-  }
-
-  .addLectureLink {
-    float: right;
-    margin-right: 16%;
-    margin-top: -1%;
     font-weight: 800;
   }
 </style>

--- a/views/lectureList/LectureListPage.vue
+++ b/views/lectureList/LectureListPage.vue
@@ -2,8 +2,8 @@
   <div>
     <header-menu></header-menu>
     <h1 class="title">강의 목록</h1>
-    <lecture-list></lecture-list>
-    <lecture-add></lecture-add>
+    <lecture-list :lectures="lectures"></lecture-list>
+    <lecture-add :lectures="lectures"></lecture-add>
   </div>
 </template>
 
@@ -11,12 +11,25 @@
   import HeaderMenu from '@/components/header/HeaderMenu'
   import LectureList from '@/admin/views/lectureList/LectureList'
   import LectureAdd from '@/admin/views/lectureList/LectureAdd'
+  import axios from 'axios'
 
   export default {
     components: {
       HeaderMenu,
       LectureList,
       LectureAdd
+    },
+    data() {
+      return {
+        lectures: []
+      }
+    },
+    created() {
+      axios.get('http://localhost:8080/server/lectures_professor.json')
+        .then((response) => {
+          this.lectures = response.data;
+          console.log(this.lectures);
+        });
     }
   }
 </script>

--- a/views/lectureList/LectureListPage.vue
+++ b/views/lectureList/LectureListPage.vue
@@ -1,0 +1,37 @@
+<template>
+  <div>
+    <header-menu></header-menu>
+    <h1 class="title">강의 목록</h1>
+    <lecture-list></lecture-list>
+  </div>
+</template>
+
+<script>
+  import HeaderMenu from '@/components/header/HeaderMenu'
+  import LectureList from '@/admin/views/lectureList/LectureList'
+
+  export default {
+    components: {
+      HeaderMenu,
+      LectureList
+    }
+  }
+</script>
+
+<style scoped>
+  h1 {
+    margin: 0;
+  }
+  .title {
+    padding: 2% 15% 2% 16%;
+    font-size: 25px;
+    font-weight: 800;
+  }
+
+  .addLectureLink {
+    float: right;
+    margin-right: 16%;
+    margin-top: -1%;
+    font-weight: 800;
+  }
+</style>


### PR DESCRIPTION
1. 강의 목록 전체 페이지
    * 로그인한 사용자(교수)의 담당 과목 목록 출력 구현
    * toggle 버튼 -> 활성화 여부
    * 강의 목록 생성 컴포넌트 구현
<img width="931" alt="관리자 강의목록 페이지1" src="https://user-images.githubusercontent.com/38181303/59159292-84758300-8b02-11e9-8bac-24a07c34d880.png">
<img width="936" alt="관리자 강의목록 페이지2" src="https://user-images.githubusercontent.com/38181303/59159294-86d7dd00-8b02-11e9-8a72-25d5c0ca99da.png">

2. 강의명 공백
   * 알림창 구현
<img width="734" alt="강의명 공백 상태" src="https://user-images.githubusercontent.com/38181303/59159312-ddddb200-8b02-11e9-90d1-067b83b0e02d.png">
 
3. 강의명 중복 x
    * 강의 추가 가능 상태 표시
<img width="698" alt="강의명 정상" src="https://user-images.githubusercontent.com/38181303/59159354-69efd980-8b03-11e9-9279-704b3941ba39.png">

4. 강의명 중복o
    * 강의 추가 불가능 상태 
<img width="677" alt="강의명 중복" src="https://user-images.githubusercontent.com/38181303/59159381-c2bf7200-8b03-11e9-9211-1a3ef398298f.png">

